### PR TITLE
ANS-59: Resolved an issue "ACOS config cannot handle looping"

### DIFF
--- a/plugins/modules/acos_config.py
+++ b/plugins/modules/acos_config.py
@@ -342,7 +342,7 @@ def main():
             for line in command_lines:
                 if not line.startswith('!'):
                     run_commands(module, line.strip())
-            run_commands(module, 'exit')
+            run_commands(module, 'end')
         except IOError:
             module.fail_json(msg="File " + module.params["file_path"] + " Not Found!")
 

--- a/tests/unit/modules/network/a10/test_acos_config.py
+++ b/tests/unit/modules/network/a10/test_acos_config.py
@@ -179,7 +179,7 @@ class TestAcosConfigModule(TestAcosModule):
                        for calls in self.run_commands.call_args_list]
         self.assertTrue(self.run_commands.called)
         self.assertIn("configure", second_args)
-        self.assertIn("exit", second_args)
+        self.assertIn("end", second_args)
         self.assertIn("ip dns primary 8.8.4.7", second_args)
         self.assertIn("port 70 tcp", second_args)
         self.assertIn("slb server serveransible2 20.20.8.26", second_args)


### PR DESCRIPTION
Modified `acos_config.py`
Instead of passing `exit` after the execution of each config file, passed `end` command sothat config mode will get ended after the execution of each config file. 
So, this is resolving the issue.

**Closes:**
- ANS-59