### PR TITLE
ANS-58 & ANS-65: Resolved Multi config issue

### DIFF
--- a/plugins/cliconf/acos.py
+++ b/plugins/cliconf/acos.py
@@ -63,7 +63,7 @@ class Cliconf(CliconfBase):
         if commit:
             try:
                 self.send_command(command='configure terminal', prompt=['(yes/no)', '(yes/no)'],
-                                        answer=["no", "no"], check_all=True)
+                                  answer=["no", "no"], check_all=True)
             except Exception:
                 raise ValueError("Unable to enter in config mode. If there is another config session running"
                                  " on device, close it before running the playbook.")

--- a/plugins/cliconf/acos.py
+++ b/plugins/cliconf/acos.py
@@ -61,8 +61,13 @@ class Cliconf(CliconfBase):
         results = []
         requests = []
         if commit:
-            self.send_command(command='configure terminal',
-                              prompt='(yes/no)', answer="yes")
+            try:
+                self.send_command(command='configure terminal', prompt=['(yes/no)', '(yes/no)'],
+                                        answer=["no", "no"], check_all=True)
+            except Exception:
+                raise ValueError("Unable to enter in config mode. If there is another config session running"
+                                 " on device, close it before running the playbook.")
+
             for line in to_list(candidate):
                 if not isinstance(line, Mapping):
                     line = {'command': line}


### PR DESCRIPTION
Modified `edit_config` method:
- Handled both the prompts getting when an user is already in config mode on vThunder and tries to run `configure terminal` again.
- This condition is now raising a ValueError showing appropriate message to the user.

**Closes:**
- ANS-58
- ANS- 65