### PR TITLE
Fix configuration diff

### DIFF
--- a/plugins/modules/acos_config.py
+++ b/plugins/modules/acos_config.py
@@ -279,6 +279,11 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.c
     NetworkConfig, dumps)
 
 
+DEFAULT_IGNORE_LINES = (
+    "Show default startup-config",
+    "exit-module",
+)
+
 def get_candidate_config(module):
     candidate = ''
     if module.params['src']:
@@ -380,7 +385,9 @@ def main():
         if "does not exist" in str(out[0]):
             module.fail_json(msg="Provided partition does not exist")
 
-    diff_ignore_lines = module.params['diff_ignore_lines']
+    diff_ignore_lines = module.params['diff_ignore_lines'] or []
+    diff_ignore_lines.extend(DEFAULT_IGNORE_LINES)
+
     match = module.params['match']
     contents = None
     flags = 'with-default' if module.params['defaults'] else []

--- a/plugins/modules/acos_config.py
+++ b/plugins/modules/acos_config.py
@@ -306,7 +306,8 @@ def get_list_from_params(command_lines):
     return candidate_obj_list
 
 
-def save_config(module):
+def save_config(module, result):
+    result["changed"] = True
     if not module.check_mode:
         run_commands(module, 'write memory\r')
     else:
@@ -455,7 +456,7 @@ def main():
     startup_config = None
 
     if module.params['save_when'] == 'always':
-        save_config(module)
+        save_config(module, result)
     elif module.params['save_when'] == 'modified':
         output = run_commands(module,
                               ['show running-config', 'show startup-config'])
@@ -464,10 +465,10 @@ def main():
         startup_config = NetworkConfig(indent=1, contents=output[1],
                                        ignore_lines=diff_ignore_lines)
         if running_config.sha1 != startup_config.sha1:
-            save_config(module)
+            save_config(module, result)
 
     elif module.params['save_when'] == 'changed' and result['changed']:
-        save_config(module)
+        save_config(module, result)
 
     if module.params['diff_against'] == 'startup':
         difference_with_startup_config = connection.get_diff(candidate=startup_config_list,


### PR DESCRIPTION
When comparing the configurations, `startup-configuration` needs to be filtered for extra commands. In addition, `changed`needs to be set explicitly to `True`, as it might not be set in some cases and Ansible won't reflect the true state.